### PR TITLE
Fixed issues #3 and #4

### DIFF
--- a/BackupKeyManager/Helpers.cs
+++ b/BackupKeyManager/Helpers.cs
@@ -77,6 +77,9 @@ namespace BackupKeyManager
                 case "CERTINFO":
                     Console.WriteLine("[Certificate] {0}", Message);
                     break;
+/*                case "ASNINFO":
+                    Console.WriteLine("[ASN] {0}", Message);
+                    break;*/
                 default:
                     break;
 

--- a/BackupKeyManager/Properties/AssemblyInfo.cs
+++ b/BackupKeyManager/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Sygnia")]
 [assembly: AssemblyProduct("BackupKeyManager")]
-[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyCopyright("Copyright 2023, SygniaLabs")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0")]
-[assembly: AssemblyFileVersion("1.0")]
+[assembly: AssemblyVersion("1.1")]
+[assembly: AssemblyFileVersion("1.1")]


### PR DESCRIPTION
- Changed certificate validity period from 1 year type to 365 days.
- Changed memory release method for data retrieved using LsaRetrievePrivateData
- Added missing memory release
- Minor console output fixes

Issues reference:
https://github.com/SygniaLabs/BackupKeyManager/issues/3
https://github.com/SygniaLabs/BackupKeyManager/issues/4
