### PR TITLE
Fix for UNICODE Encoding issue

### DIFF
--- a/BackupKeyManager/Interop.cs
+++ b/BackupKeyManager/Interop.cs
@@ -20,6 +20,15 @@ namespace BackupKeyManager
                 buffer = Marshal.StringToHGlobalUni(s);
             }
 
+            public LSA_UNICODE_STRING(byte[] ba)
+            {
+                Length = (ushort)(ba.Length);
+                MaximumLength = Length;
+                buffer = Marshal.AllocHGlobal(Length);
+
+                Marshal.Copy(ba, 0, buffer, ba.Length);
+            }
+
             public void Dispose()
             {
                 Marshal.FreeHGlobal(buffer);

--- a/BackupKeyManager/Program.cs
+++ b/BackupKeyManager/Program.cs
@@ -270,12 +270,8 @@ namespace BackupKeyManager
 
         public static void SetBackupKeyValue(IntPtr BackupKeyHandle, byte[] BackupKeyValueByte)
         {
-
-            string BackupKeyValueStr = System.Text.Encoding.Unicode.GetString(BackupKeyValueByte);
-            Interop.LSA_UNICODE_STRING BackupKeyValueStrLSA = new Interop.LSA_UNICODE_STRING(BackupKeyValueStr);
-
-            //IntPtr BackupKeyValueStrLSAPointer = Marshal.AllocHGlobal(Marshal.SizeOf(BackupKeyValueStrLSA));
-            //Marshal.StructureToPtr(BackupKeyValueStrLSA, BackupKeyValueStrLSAPointer, false);
+            
+            Interop.LSA_UNICODE_STRING BackupKeyValueStrLSA = new Interop.LSA_UNICODE_STRING(BackupKeyValueByte);
 
             Helpers.LogLine("INFO", "Writing bytes to Backup key...");
             uint ntsResult = Interop.LsaSetSecret(BackupKeyHandle, ref BackupKeyValueStrLSA, ref BackupKeyValueStrLSA);
@@ -808,7 +804,6 @@ namespace BackupKeyManager
 
 
             Guid bkpGuid = new Guid(guidArr);
-
 
             if (bkpGuid.Equals(Guid.Empty) || maxAttempts >= 1000)
             {


### PR DESCRIPTION
This PR fixes a UNICODE encoding issue where in certain cases of key push, bytes FD FF replaced other bytes within the Backup key raw bytes, causing invalid structure for the key or certificate part.